### PR TITLE
Pinned pytorch version to 2.6.0 which is required by chatterbox-tts 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ python -m venv myenv
 myenv\Scripts\activate.bat
 
 # Install PyTorch with CUDA 11.8
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118
 
 # Install ChatterboxTTS and Gradio
 pip install chatterbox-tts gradio

--- a/install.bat
+++ b/install.bat
@@ -4,7 +4,7 @@ echo Creating environment and installing Chatterbox-TTS-WebUI...
 python -m venv myenv
 call myenv\Scripts\activate.bat
 pip install chatterbox-tts gradio
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118
 
 echo Done! Run run_tts.bat 
 pause


### PR DESCRIPTION
Hi and thank you for sharing your work :)

Your `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 ` installs the latest pytorch version (at the moment 2.7.1)  which is incompatible with the latest chatterbox-tts (at the moment 0.1.2) python package.  So, i took the liberty to pin it to the required version 2.6.0.

```
# This command stems from https://pytorch.org/get-started/previous-versions/

pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118
```

